### PR TITLE
Let pytest capture test output

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     requests_mock
     -r requirements.txt
 commands =
-    pytest -s {posargs}
+    pytest {posargs}
 setenv =
     AWS_ACCESS_KEY_ID = mock
     AWS_SECRET_ACCESS_KEY = mock


### PR DESCRIPTION
This un-garbles the test output, making actual warnings easier to spot, while still showing the captured output from tests when they do fail.