### PR TITLE
Make the `jsonschema` package work

### DIFF
--- a/serverless.yaml
+++ b/serverless.yaml
@@ -88,7 +88,13 @@ custom:
   version: 0.1.0
   pythonRequirements:
     dockerizePip: non-linux
+    useDownloadCache: false
+    useStaticCache: false
     slim: true
+    slimPatternsAppendDefaults: false
+    slimPatterns:
+      - '**/*.py[c|o]'
+      - '**/__pycache__*'
     usePoetry: false
   esLogs:
     endpoint: ${ssm:/dataplatform/shared/logs-elasticsearch-endpoint}


### PR DESCRIPTION
Make necessary packaging tweaks (taken from the discussion at https://github.com/Julian/jsonschema/issues/584) to make the `jsonschema` package work when running in AWS Lambda.