### PR TITLE
Don't include fastparquet's test dir in bundle

### DIFF
--- a/serverless.yaml
+++ b/serverless.yaml
@@ -100,6 +100,7 @@ custom:
     slimPatterns:
       - '**/*.py[c|o]'
       - '**/__pycache__*'
+      - 'fastparquet/test'
     usePoetry: false
   esLogs:
     endpoint: ${ssm:/dataplatform/shared/logs-elasticsearch-endpoint}


### PR DESCRIPTION
Fastparquet's test directory is pretty big, making our bundle exceed AWS Lambda's 250 MB size limit. Don't include it.