### PR TITLE
DP-1629 Use `accessRights` instead of `confidentiality`

### DIFF
--- a/okdata/pipeline/common.py
+++ b/okdata/pipeline/common.py
@@ -1,0 +1,5 @@
+CONFIDENTIALITY_MAP = {
+    "public": "green",
+    "restricted": "yellow",
+    "non-public": "red",
+}

--- a/okdata/pipeline/writers/kinesis/handler.py
+++ b/okdata/pipeline/writers/kinesis/handler.py
@@ -8,6 +8,7 @@ from aws_xray_sdk.core import patch_all, xray_recorder
 from requests.exceptions import HTTPError, Timeout
 
 from okdata.aws.logging import logging_wrapper, log_add
+from okdata.pipeline.common import CONFIDENTIALITY_MAP
 from okdata.pipeline.models import Config, StepData
 from okdata.sdk.config import Config as OrigoSdkConfig
 from okdata.sdk.data.dataset import Dataset
@@ -50,7 +51,8 @@ def write_kinesis(event, context):
     log_add(dataset_id=dataset_id, version=version)
 
     dataset = get_dataset(dataset_id)
-    confidentiality = dataset["confidentiality"]
+    access_rights = dataset["accessRights"]
+    confidentiality = CONFIDENTIALITY_MAP[access_rights]
 
     output_stream_name = f"dp.{confidentiality}.{dataset_id}.processed.{version}.json"
     log_add(output_stream_name=output_stream_name)

--- a/test/writers/kinesis/handler_test.py
+++ b/test/writers/kinesis/handler_test.py
@@ -15,6 +15,7 @@ utc_now = "2019-06-26T08:55:00+00:00"
 uuid_str = "d80ef25f-5f97-4326-b524-50154006f0ba"
 dataset_id = "some-id"
 version = "some_version"
+access_rights = "public"
 confidentiality = "green"
 
 input_events = [{"foo": "bar"}, {"foo": "car"}]
@@ -90,6 +91,6 @@ def mock_dataset_client(monkeypatch):
     def get_dataset(self, dataset_id):
         if dataset_id == "error":
             raise HTTPError
-        return {"confidentiality": confidentiality}
+        return {"accessRights": access_rights}
 
     monkeypatch.setattr(Dataset, "get_dataset", get_dataset)


### PR DESCRIPTION
Look at `accessRights` instead of `confidentiality` when determining dataset access level.