### PR TITLE
DP-1988 Increase memory for `csv-to-parquet`

### DIFF
--- a/serverless.yaml
+++ b/serverless.yaml
@@ -39,7 +39,7 @@ package:
 functions:
   csv-to-parquet:
     handler: okdata.pipeline.converters.csv.handler.csv_to_parquet
-    memorySize: 3008
+    memorySize: 10240
     timeout: 900
   invoke-lambda:
     handler: okdata.pipeline.lambda_invoker.invoke_lambda


### PR DESCRIPTION
Increase the memory size for the `csv-to-parquet` pipeline to the new Lambda maximum of 10 GB.