### PR TITLE
DP-2162 Handle JSON errors at root

### DIFF
--- a/okdata/pipeline/validators/jsonschema_validator.py
+++ b/okdata/pipeline/validators/jsonschema_validator.py
@@ -61,12 +61,13 @@ class JsonSchemaValidator:
         log_add(raw_errors=raw_errors)
         errors = []
         for e in raw_errors:
-            row = e.path[0]
-            if len(e.path) > 1:
-                col = e.path[1]
-                errors.append({"row": row, "column": col, "message": e.message})
-            else:
-                errors.append({"row": row, "message": e.message})
+            error = {"message": e.message, "row": "root"}
+            path_len = len(e.path)
+            if path_len > 0:
+                error["row"] = e.path[0]
+                if path_len > 1:
+                    error["col"] = e.path[1]
+            errors.append(error)
 
         return errors
 

--- a/test/validators/jsonschema_validator_test.py
+++ b/test/validators/jsonschema_validator_test.py
@@ -138,3 +138,14 @@ class TestValidJsonSchema:
         ]
         validation_errors = JsonSchemaValidator(json_schema).validate_list(json_data)
         assert len(validation_errors) == 1
+
+    def test_validate_list_missing_datetime_column(self, json_schema):
+        json_data = [
+            {
+                "id": "1",
+                "year": "2020",
+                "date": "2020-01-01",
+            }
+        ]
+        validation_errors = JsonSchemaValidator(json_schema).validate_list(json_data)
+        assert len(validation_errors) == 1


### PR DESCRIPTION
This change adds handling of JSON validation errors w/o a path.

E.g. if given a schema requiring the keys `a` and `b`, an object like
`{"a": 123}` will give a validation error of `"'b' is a required property"`,
but would not have a path.

`path` and `relative_path` are empty for validation errors at root:
https://python-jsonschema.readthedocs.io/en/latest/errors/#jsonschema.exceptions.ValidationError.relative_path