### PR TITLE
DP-2162 Send JSON validation errors to status API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ node_modules/
 
 # Jetbrains
 .idea/
+
+# VS Code
+.vscode/

--- a/okdata/pipeline/validators/json/s3_reader.py
+++ b/okdata/pipeline/validators/json/s3_reader.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import boto3
@@ -13,4 +14,4 @@ def read_s3_data(s3_input_prefixes: dict) -> list:
     s3_path = next(iter(objects["Contents"]))["Key"]
 
     response = s3.get_object(Bucket=BUCKET, Key=s3_path)
-    return [response["Body"].read().decode("utf-8")]
+    return [json.loads(response["Body"].read().decode("utf-8"))]

--- a/okdata/pipeline/validators/json/s3_reader.py
+++ b/okdata/pipeline/validators/json/s3_reader.py
@@ -6,11 +6,11 @@ s3 = boto3.client("s3")
 BUCKET = os.environ["BUCKET_NAME"]
 
 
-def read_s3_data(s3_input_prefixes: dict) -> str:
+def read_s3_data(s3_input_prefixes: dict) -> list:
     prefix = next(iter(s3_input_prefixes.values()))
 
     objects = s3.list_objects_v2(Bucket=BUCKET, Prefix=prefix)
     s3_path = next(iter(objects["Contents"]))["Key"]
 
     response = s3.get_object(Bucket=BUCKET, Key=s3_path)
-    return response["Body"].read().decode("utf-8")
+    return [response["Body"].read().decode("utf-8")]

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -50,6 +50,9 @@ functions:
     handler: okdata.pipeline.validators.csv.validator.validate_csv
   validate-json:
     handler: okdata.pipeline.validators.json.handler.validate_json
+    environment:
+      OKDATA_CLIENT_ID: json-writer
+      OKDATA_CLIENT_SECRET: ${ssm:/dataplatform/json-writer/keycloak-client-secret~true}
   write-kinesis:
     handler: okdata.pipeline.writers.kinesis.handler.write_kinesis
     timeout: 70

--- a/test/validators/json/data/schema_array.json
+++ b/test/validators/json/data/schema_array.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": [
+      "id",
+      "name",
+      "created"
+    ],
+    "properties": {
+      "id": {
+        "type": "string"
+      },
+      "name": {
+        "type": "string"
+      },
+      "created": {
+        "type": "string",
+        "format": "date-time"
+      }
+    }
+  }
+}

--- a/test/validators/json/handler_test.py
+++ b/test/validators/json/handler_test.py
@@ -88,7 +88,9 @@ def test_s3_input(lambda_event, spy_read_s3_data, mock_status_requests):
     assert spy_read_s3_data.call_count == 1
 
 
-def test_handle_multiple_realtime_events(lambda_event, validation_success):
+def test_handle_multiple_realtime_events(
+    lambda_event, validation_success, mock_status_requests
+):
     events = [
         {"foo": "bar"},
         {"bar": "foo"},

--- a/test/validators/json/handler_test.py
+++ b/test/validators/json/handler_test.py
@@ -9,7 +9,7 @@ import pytest
 from okdata.aws.status.sdk import Status
 from okdata.pipeline.exceptions import IllegalWrite
 from okdata.pipeline.models import StepData
-from okdata.pipeline.validators.json.handler import validate_json, format_errors_message
+from okdata.pipeline.validators.json.handler import format_error_messages, validate_json
 from okdata.pipeline.validators.jsonschema_validator import JsonSchemaValidator
 
 test_data_directory = Path(os.path.dirname(__file__), "data")
@@ -58,13 +58,7 @@ def test_validation_failed(
     )
     assert status_add_spy.call_count == 2
     assert status_add_spy.call_args == (
-        {
-            "errors": [
-                {
-                    "message": format_errors_message(validation_errors),
-                }
-            ]
-        },
+        {"errors": format_error_messages(validation_errors)},
     )
 
 
@@ -91,13 +85,7 @@ def test_validation_failed_for_array(
     )
     assert status_add_spy.call_count == 2
     assert status_add_spy.call_args == (
-        {
-            "errors": [
-                {
-                    "message": format_errors_message(validation_errors_for_array),
-                }
-            ]
-        },
+        {"errors": format_error_messages(validation_errors_for_array)},
     )
 
 
@@ -146,17 +134,13 @@ def test_s3_invalid_json(
     assert status_add_spy.call_count == 2
     assert status_add_spy.call_args == (
         {
-            "errors": [
-                {
-                    "message": format_errors_message(
-                        [
-                            {
-                                "message": "Expecting property name enclosed in double quotes: line 1 column 2 (char 1)"
-                            }
-                        ]
-                    ),
-                }
-            ]
+            "errors": format_error_messages(
+                [
+                    {
+                        "message": "Expecting property name enclosed in double quotes: line 1 column 2 (char 1)"
+                    }
+                ]
+            )
         },
     )
 

--- a/test/validators/json/handler_test.py
+++ b/test/validators/json/handler_test.py
@@ -108,7 +108,7 @@ def test_handle_multiple_realtime_events(lambda_event, validation_success):
     )
 
 
-def test_illegal_input_count_s3(lambda_event):
+def test_illegal_input_count_s3(lambda_event, mock_status_requests):
     lambda_event_illegal_input_count_s3 = lambda_event
     lambda_event_illegal_input_count_s3["payload"]["step_data"]["input_events"] = None
     lambda_event_illegal_input_count_s3["payload"]["step_data"]["s3_input_prefixes"] = {

--- a/test/validators/json/s3_reader_test.py
+++ b/test/validators/json/s3_reader_test.py
@@ -1,3 +1,4 @@
+import json
 import okdata.pipeline.validators.json.s3_reader as s3_reader
 from test.util import mock_aws_s3_client
 
@@ -6,13 +7,16 @@ test_prefix = "/a/path/to/somehwere"
 
 
 def test_s3_reader_read_s3_data(mocker):
+    test_data = {"foo": "bar", "bar": "foo"}
+
     s3_client_mock = mock_aws_s3_client(test_bucket)
     s3_client_mock.put_object(
         Bucket=test_bucket,
         Key=f"{test_prefix}the-file.json",
-        Body="asdfasdf".encode("utf-8"),
+        Body=json.dumps(test_data).encode("utf-8"),
     )
 
     mocker.patch("okdata.pipeline.validators.json.s3_reader.BUCKET", test_bucket)
     mocker.patch("okdata.pipeline.validators.json.s3_reader.s3", s3_client_mock)
-    assert s3_reader.read_s3_data({"the-dataset-id": test_prefix}) == ["asdfasdf"]
+    output = s3_reader.read_s3_data({"the-dataset-id": test_prefix})
+    assert output == [test_data]

--- a/test/validators/json/s3_reader_test.py
+++ b/test/validators/json/s3_reader_test.py
@@ -15,4 +15,4 @@ def test_s3_reader_read_s3_data(mocker):
 
     mocker.patch("okdata.pipeline.validators.json.s3_reader.BUCKET", test_bucket)
     mocker.patch("okdata.pipeline.validators.json.s3_reader.s3", s3_client_mock)
-    assert s3_reader.read_s3_data({"the-dataset-id": test_prefix}) == "asdfasdf"
+    assert s3_reader.read_s3_data({"the-dataset-id": test_prefix}) == ["asdfasdf"]


### PR DESCRIPTION
Feilmeldinger ved validering av JSON blir sendt til status-API-et.

<details>
<summary>
Eksempel i frontend - et array med JSON objects hvor object nr. 3 mangler en required key <code>created</code>.
</summary>

<img width="1424" alt="Screenshot 2021-08-10 at 12 04 24" src="https://user-images.githubusercontent.com/773079/128870502-2a88a6f2-8d50-48ba-8173-a897a1552c4c.png">
</details>

<details>
<summary>
Eksempel med <code>okdata</code> - JSON som ble lasta opp kunne ikke parses.
</summary>

![image](https://user-images.githubusercontent.com/773079/128870656-05943a0f-2155-470d-bc18-b54ccc44bb16.png)
</details>

NB: Feilmeldinger fra `jsonschema` blir ikke oversatt til norsk ettersom dette biblioteket ikke støtter oversettelser. Det vil kreve mye arbeid å sette opp og vedlikeholde en egen løsning for å oversette meldingene som biblioteket lager.

Ting for å teste i dev:
* Datasett: https://devportal-frontend.data-dev.oslo.systems/katalog/data/dp-2162-test-2
* Pipeline: https://github.com/oslokommune/okdata-pipeline-config/tree/7b643ada2a08fc85708c6f14a692454432441392/data/pipeline_instances/dp-2162-test-2