### PR TITLE
Run tests in `test/converters/xls/main_test.py`

### DIFF
--- a/test/converters/xls/main_test.py
+++ b/test/converters/xls/main_test.py
@@ -1,7 +1,8 @@
 import os
 import sys
 
-from okdata.pipeline.converters.xls.main import xls_to_csv
+from moto import mock_s3
+
 from test.util import mock_aws_s3_client
 
 CWD = os.path.dirname(os.path.realpath(__file__))
@@ -60,72 +61,90 @@ event_default = {
 expected_content = "A;B\n" + "1;foo\n" + "2;bar\n" + "3;baz\n"
 
 
-class MainTest:
-    def test_xls_to_csv():
-        s3_mock = mock_aws_s3_client(bucket)
+@mock_s3
+def test_xls_to_csv():
+    from okdata.pipeline.converters.xls.main import xls_to_csv
 
-        excel_path = os.path.join(CWD, "data", "simple.xlsx")
-        upload_key = "raw/green/dataset-in/1/20181115/simple.xlsx"
-        output_prefix = "intermediate/yellow/dataset-out/1/20200123/xls2csv/"
-        download_key = output_prefix + "simple.csv"
+    s3_mock = mock_aws_s3_client(bucket)
 
+    excel_path = os.path.join(CWD, "data", "simple.xlsx")
+    upload_key = "raw/green/dataset-in/1/20181115/simple.xlsx"
+    output_prefix = "intermediate/yellow/dataset-out/1/20200123/xls2csv/"
+    download_key = output_prefix + "simple.csv"
+
+    with open(excel_path, "rb") as f:
+        s3_mock.put_object(Bucket=bucket, Key=upload_key, Body=f)
+
+    response = xls_to_csv(event, 0)
+    assert response["status"] == "OK"
+    assert response["s3_input_prefixes"]["dataset-out"] == output_prefix
+
+    content = (
+        s3_mock.get_object(Bucket=bucket, Key=download_key)
+        .get("Body")
+        .read()
+        .decode("utf-8")
+    )
+    # To avoid a failed test when running on Windows
+    content = content.replace("\r", "")
+
+    assert content == expected_content
+
+
+@mock_s3
+def test_xls_to_csv_multiple_files():
+    from okdata.pipeline.converters.xls.main import xls_to_csv
+
+    s3_mock = mock_aws_s3_client(bucket)
+
+    excel_path = os.path.join(CWD, "data", "simple.xlsx")
+    upload_prefix = "raw/green/dataset-in/1/20181115/"
+    output_prefix = "intermediate/yellow/dataset-out/1/20200123/xls2csv/"
+
+    for k in ["simple1.xlsx", "simple2.xlsx"]:
         with open(excel_path, "rb") as f:
-            s3_mock.Object(bucket, upload_key).put(Body=f)
+            s3_mock.put_object(Bucket=bucket, Key=upload_prefix + k, Body=f)
 
-        response = xls_to_csv(event, 0)
-        assert response["status"] == "OK"
-        assert response["s3_input_prefixes"]["dataset-out"] == output_prefix
+    response = xls_to_csv(event, 0)
+    assert response["status"] == "OK"
+    assert response["s3_input_prefixes"]["dataset-out"] == output_prefix
 
+    for filename in ["simple1.csv", "simple2.csv"]:
+        k = output_prefix + filename
         content = (
-            s3_mock.Object(bucket, download_key).get()["Body"].read().decode("utf-8")
+            s3_mock.get_object(Bucket=bucket, Key=k).get("Body").read().decode("utf-8")
         )
         # To avoid a failed test when running on Windows
         content = content.replace("\r", "")
 
         assert content == expected_content
 
-    def test_xls_to_csv_multiple_files():
-        s3_mock = mock_aws_s3_client(bucket)
 
-        excel_path = os.path.join(CWD, "data", "simple.xlsx")
-        upload_prefix = "raw/green/dataset-in/1/20181115/"
-        output_prefix = "intermediate/yellow/dataset-out/1/20200123/xls2csv/"
+@mock_s3
+def test_xls_to_csv_default_config():
+    from okdata.pipeline.converters.xls.main import xls_to_csv
 
-        for k in ["simple1.xlsx", "simple2.xlsx"]:
-            with open(excel_path, "rb") as f:
-                s3_mock.Object(bucket, upload_prefix + k).put(Body=f)
+    s3_mock = mock_aws_s3_client(bucket)
 
-        response = xls_to_csv(event, 0)
-        assert response["status"] == "OK"
-        assert response["s3_input_prefixes"]["dataset-out"] == output_prefix
+    excel_path = os.path.join(CWD, "data", "simple.xlsx")
+    upload_key = "raw/green/dataset-in/1/20181115/simple.xlsx"
+    output_prefix = "intermediate/yellow/dataset-out/1/20200123/xls2csv/"
+    download_key = output_prefix + "simple.csv"
 
-        for filename in ["simple1.csv", "simple2.csv"]:
-            k = output_prefix + filename
-            content = s3_mock.Object(bucket, k).get()["Body"].read().decode("utf-8")
-            # To avoid a failed test when running on Windows
-            content = content.replace("\r", "")
+    with open(excel_path, "rb") as f:
+        s3_mock.put_object(Bucket=bucket, Key=upload_key, Body=f)
 
-            assert content == expected_content
+    response = xls_to_csv(event_default, 0)
+    assert response["status"] == "OK"
+    assert response["s3_input_prefixes"]["dataset-out"] == output_prefix
 
-    def test_xls_to_csv_default_config():
-        s3_mock = mock_aws_s3_client(bucket)
+    content = (
+        s3_mock.get_object(Bucket=bucket, Key=download_key)
+        .get("Body")
+        .read()
+        .decode("utf-8")
+    )
+    # To avoid a failed test when running on Windows
+    content = content.replace("\r", "")
 
-        excel_path = os.path.join(CWD, "data", "simple.xlsx")
-        upload_key = "raw/green/dataset-in/1/20181115/simple.xlsx"
-        output_prefix = "intermediate/yellow/dataset-out/1/20200123/xls2csv/"
-        download_key = output_prefix + "simple.csv"
-
-        with open(excel_path, "rb") as f:
-            s3_mock.Object(bucket, upload_key).put(Body=f)
-
-        response = xls_to_csv(event_default, 0)
-        assert response["status"] == "OK"
-        assert response["s3_input_prefixes"]["dataset-out"] == output_prefix
-
-        content = (
-            s3_mock.Object(bucket, download_key).get()["Body"].read().decode("utf-8")
-        )
-        # To avoid a failed test when running on Windows
-        content = content.replace("\r", "")
-
-        assert content == expected_content
+    assert content == expected_content


### PR DESCRIPTION
The tests in `test/converters/xls/main_test.py` weren't running because the name of the class they were wrapped in didn't start with `Test`. Unwrapping them from the class revealed that they were all failing, so fix them up bit as well.