### PR TITLE
Skip CSV validation in schema-less pipelines again

### DIFF
--- a/okdata/pipeline/validators/csv/validator.py
+++ b/okdata/pipeline/validators/csv/validator.py
@@ -70,6 +70,16 @@ def validate_csv(event, context):
         output_prefix=s3_prefix,
     )
 
+    # FIXME: The validator is running too slowly on Deichman's three largest
+    # datasets (7,8 million lines and up). Skip validation for schema-less
+    # pipelines still, until the validator can handle them.
+    if not step_config.schema:
+        log_add(notice="No Schema provided for validation")
+        config.payload.step_data.status = Status.VALIDATION_SUCCESS.value
+        # 2020.06: Validation done optionally - we now return ok if we don't supply a
+        # schema for the validation step
+        return asdict(config.payload.step_data)
+
     input_prefix = next(iter(config.payload.step_data.s3_input_prefixes.values()))
     log_add(s3_input_prefix=input_prefix)
     objects = s3.list_objects_v2(Bucket=BUCKET, Prefix=input_prefix)


### PR DESCRIPTION
The CSV validator is running too slowly on Deichman's three largest datasets (7,8 million lines and up). Skip validation for schema-less pipelines still, until the validator can handle them.