### PR TITLE
DP-2329 Drop per-function policies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5430,15 +5430,6 @@
         "lodash": "4.17.20"
       }
     },
-    "serverless-granular-iam": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/serverless-granular-iam/-/serverless-granular-iam-2.1.0.tgz",
-      "integrity": "sha512-nEBfO5GgtzEJ/JGUpKuHG6NAsbWhirdnO4QidoE+V7DcgQt/vSFbSNYWBVKvOs64XjUzkN4T5hNVXQgu42pnug==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.15"
-      }
-    },
     "serverless-plugin-git-variables": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/serverless-plugin-git-variables/-/serverless-plugin-git-variables-5.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "devDependencies": {
     "serverless": "^1.83.2",
     "serverless-es-logs": "^3.4.1",
-    "serverless-granular-iam": "^2.1.0",
     "serverless-plugin-git-variables": "^5.0.1",
     "serverless-pseudo-parameters": "^2.5.0",
     "serverless-python-requirements": "^5.1.0"

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -1,4 +1,3 @@
-# The `serverless-granular-iam` plugin only supports Serverless 1.x.
 frameworkVersion: ">=1.64.0 <2.0.0"
 
 service: okdata-pipeline
@@ -45,9 +44,6 @@ functions:
     timeout: 900
   invoke-lambda:
     handler: okdata.pipeline.lambda_invoker.invoke_lambda
-    iamRoleStatements: []
-    iamManagedPolicies:
-      - arn:aws:iam::#{AWS::AccountId}:policy/lambda-invoker-policy
   validate-csv:
     handler: okdata.pipeline.validators.csv.validator.validate_csv
   validate-json:
@@ -55,25 +51,16 @@ functions:
   write-kinesis:
     handler: okdata.pipeline.writers.kinesis.handler.write_kinesis
     timeout: 70
-    iamRoleStatements: []
-    iamManagedPoliciesInherit: true
-    iamManagedPolicies:
-      - arn:aws:iam::#{AWS::AccountId}:policy/kinesis-writer-policy
   write-s3:
     handler: okdata.pipeline.writers.s3.handlers.write_s3
     timeout: 900
     tracing: Active
-    iamRoleStatements: []
-    iamManagedPoliciesInherit: true
-    iamManagedPolicies:
-      - arn:aws:iam::#{AWS::AccountId}:policy/s3_writer_policy
   xls-to-csv:
     handler: okdata.pipeline.converters.xls.main.xls_to_csv
     timeout: 120
 
 plugins:
   - serverless-es-logs
-  - serverless-granular-iam
   - serverless-plugin-git-variables
   - serverless-pseudo-parameters
   - serverless-python-requirements


### PR DESCRIPTION
The common `pipeline_component_policy` will cover everything previously covered by the per-function policies `kinesis-writer-policy`, `lambda-invoker-policy`, and `s3-writer-policy`.

Depends on https://github.com/oslokommune/dataplatform-config/pull/49 being applied.