### PR TITLE
Unbreak tests by pinning `responses`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,18 @@ envlist = py37, flake8, black
 
 [testenv]
 deps =
-    freezegun
-    moto>=2.0.2
-    pytest
-    pytest-mock
-    requests_mock
+    freezegun==1.1.0
+    moto==2.3.1
+    pytest==6.2.5
+    pytest-mock==3.6.1
+    requests_mock==1.9.3
+    # XXX: Version 0.17.0 breaks our tests in mysterious ways, so pin
+    #      it to the previous version. We don't use this library
+    #      directly, but it's a sub-dependency of moto.
+    #
+    #      Possibly relevant:
+    #      https://github.com/getsentry/responses/issues/467
+    responses==0.16.0
     -r requirements.txt
 commands =
     pytest {posargs}


### PR DESCRIPTION
The newest 0.17.0 version of the `repsonses` library breaks our tests in mysterious ways, so pin it to the previous 0.16.0 version. We don't use this library directly, but it's a sub-dependency of `moto`.

Possibly relevant: https://github.com/getsentry/responses/issues/467.

Also pin the top-level test dependencies to make the version cocktail more predictable.