### PR TITLE
Upgrade Python and NumPy

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install Python dependencies
       run: pip install tox
     - name: Test with tox

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install Python dependencies
       run: pip install tox
     - name: Test with tox

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install dependencies
       run: pip install tox
     - name: Test with tox

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Dataplattform](https://oslokommune.github.io/dataplattform/).
 ## Setup
 
 1. Install [Serverless Framework](https://serverless.com/framework/docs/getting-started/)
-2. python3.7 -m venv .venv
+2. python3.8 -m venv .venv
 3. Install Serverless plugins: `make init`
 4. Install Python toolchain: `python3 -m pip install (--user) tox black pip-tools`
    - If running with `--user` flag, add `$HOME/.local/bin` to `$PATH`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ['py37']
+target-version = ['py38']
 # Keep exclude in sync with flake8 config in tox.ini
 exclude = '''
 /(

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ llvmlite==0.36.0
     # via numba
 numba==0.53.1
     # via fastparquet
-numpy==1.21.0
+numpy==1.22.4
     # via
     #   fastparquet
     #   numba

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -4,7 +4,7 @@ service: okdata-pipeline
 
 provider:
   name: aws
-  runtime: python3.7
+  runtime: python3.8
   region: ${opt:region, 'eu-west-1'}
   stage: ${opt:stage, 'dev'}
   timeout: 60

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, flake8, black
+envlist = py38, flake8, black
 
 [testenv]
 deps =


### PR DESCRIPTION
Upgrade Python to 3.8 since NumPy 1.21 doesn't support Python 3.7.

Upgrade NumPy to 1.22 since Python 3.8 doesn't support NumPy 1.21.