### PR TITLE
Replace xlrd with openpyxl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,8 @@ charset-normalizer==3.3.2
     # via requests
 ecdsa==0.14.1
     # via python-jose
+et-xmlfile==1.1.0
+    # via openpyxl
 fastparquet==0.5.0
     # via okdata-pipeline (setup.py)
 fsspec==2021.4.0
@@ -55,6 +57,8 @@ okdata-sdk==3.1.0
     # via
     #   okdata-aws
     #   okdata-pipeline (setup.py)
+openpyxl==3.1.2
+    # via okdata-pipeline (setup.py)
 pandas==1.2.4
     # via
     #   fastparquet
@@ -118,8 +122,6 @@ urllib3==1.26.18
     #   requests
 wrapt==1.12.1
     # via aws-xray-sdk
-xlrd==1.2.0
-    # via okdata-pipeline (setup.py)
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setuptools.setup(
         "jsonschema",
         "okdata-aws>=0.4.1",
         "okdata-sdk>=2.1.0",
+        "openpyxl",
         "pandas",
         # Lock to Lambda runtime version
         "python-dateutil==2.8.2",
@@ -44,8 +45,6 @@ setuptools.setup(
         "six==1.16.0",
         # Lambda runtime has a vulnerable version; ship our own
         "urllib3>=1.26.18",
-        # Newer versions drop support for newer Excel files (.xlsx)
-        "xlrd<2.0",
     ],
     python_requires="==3.9.*",
 )

--- a/test/converters/xls/TableConverter_test.py
+++ b/test/converters/xls/TableConverter_test.py
@@ -3,8 +3,8 @@ import sys
 import unittest
 from copy import copy
 
+import openpyxl
 import pandas as pd
-import xlrd
 
 from okdata.pipeline.converters.xls.TableConfig import TableConfig
 from okdata.pipeline.converters.xls.TableConverter import TableConverter
@@ -87,19 +87,19 @@ class Tester(unittest.TestCase):
         conv = TableConverter(config)
         wb = conv.read_excel_table(os.path.join(CWD, "data", "simple.xlsx"))
 
-        self.assertEqual(type(wb), xlrd.book.Book)
+        assert isinstance(wb, openpyxl.Workbook)
 
     def test_read_wrong_sheet_name(self):
         conv = TableConverter(wrong_sheet_name_config)
         wb = conv.read_excel_table(os.path.join(CWD, "data", "simple.xlsx"))
 
         with self.assertRaises(ValueError):
-            conv.extract_sub_table(wb, wrong_sheet_name_config.table_sources[0])
+            conv._extract_sub_table(wb, wrong_sheet_name_config.table_sources[0])
 
     def test_read_wo_header(self):
         conv = TableConverter(no_header_config)
         wb = conv.read_excel_table(os.path.join(CWD, "data", "simple.xlsx"))
-        df = conv.extract_sub_table(wb, no_header_config.table_sources[0])
+        df = conv._extract_sub_table(wb, no_header_config.table_sources[0])
 
         self.assertEqual(type(df), pd.DataFrame)
         self.assertEqual(list(df.columns), ["A_specified", "B_specified"])
@@ -110,7 +110,7 @@ class Tester(unittest.TestCase):
     def test_extract_sub_table(self):
         conv = TableConverter(config)
         wb = conv.read_excel_table(os.path.join(CWD, "data", "simple.xlsx"))
-        df = conv.extract_sub_table(wb, config.table_sources[0])
+        df = conv._extract_sub_table(wb, config.table_sources[0])
 
         self.assertEqual(type(df), pd.DataFrame)
         self.assertEqual(list(df.columns), ["A", "B"])
@@ -125,7 +125,7 @@ class Tester(unittest.TestCase):
 
         wb = conv.read_excel_table(os.path.join(CWD, "data", "simple.xlsx"))
         with self.assertRaises(ValueError):
-            conv.extract_sub_table(wb, config.table_sources[0])
+            conv._extract_sub_table(wb, config.table_sources[0])
 
     def test_convert_with_empty_config(self):
         conv = TableConverter(empty_config)


### PR DESCRIPTION
The xlrd library has dropped support for modern Excel files (.xlsx) since version 2, and is either way no longer maintained.

Replace it with openpyxl for XLSX support. The XLS legacy format that was supported by xlrd is no longer supported in okdata-pipeline.