### PR TITLE
Preserve S3 "directories" in the S3 writer

### DIFF
--- a/okdata/pipeline/writers/s3/services.py
+++ b/okdata/pipeline/writers/s3/services.py
@@ -63,7 +63,7 @@ class S3Service:
 
         for obj in source_objects:
             source_key = obj["Key"]
-            filename = source_key.split("/")[-1]
+            filename = source_key.removeprefix(source_prefix)
             s3_sources.append(S3Source(filename=filename, key=source_key))
 
         return s3_sources

--- a/test/writers/s3/test_data.py
+++ b/test/writers/s3/test_data.py
@@ -6,6 +6,8 @@ edition = "20200120T133701"
 
 file_name_1 = "file1.json"
 file_name_2 = "file2.json"
+# Test that S3 "directories" are preserved when files are copied
+file_name_3 = "subdir/file3.json"
 
 s3_input_prefix = f"raw/green/{dataset_id}/version={version}/edition={edition}/"
 s3_output_prefix_processed = (
@@ -18,7 +20,7 @@ s3_output_prefix_processed_latest = (
     f"processed/green/{dataset_id}/version={version}/latest/"
 )
 
-filenames = [file_name_1, file_name_2]
+filenames = [file_name_1, file_name_2, file_name_3]
 
 s3_sources = [
     S3Source(
@@ -28,6 +30,10 @@ s3_sources = [
     S3Source(
         filename=file_name_2,
         key=f"{s3_input_prefix}{file_name_2}",
+    ),
+    S3Source(
+        filename=file_name_3,
+        key=f"{s3_input_prefix}{file_name_3}",
     ),
 ]
 

--- a/test/writers/s3/test_services.py
+++ b/test/writers/s3/test_services.py
@@ -8,10 +8,12 @@ from test.util import mock_aws_s3_client
 
 file_content_1 = "nfjanfdafmkadmfa"
 file_content_2 = "djnfjandjfnsekjg"
+file_content_3 = "dmlybyhgunoumzas"
 
 test_files = [
     {"filename": test_data.file_name_1, "content": file_content_1.encode("utf-8")},
     {"filename": test_data.file_name_2, "content": file_content_2.encode("utf-8")},
+    {"filename": test_data.file_name_3, "content": file_content_3.encode("utf-8")},
 ]
 
 
@@ -19,7 +21,7 @@ def test_copy(mock_aws):
     s3_service = S3Service()
     s3_service.copy(test_data.s3_sources, test_data.s3_output_prefix_processed)
     object_list = s3_service.list_objects_contents(test_data.s3_output_prefix_processed)
-    assert len(object_list) == 2
+    assert len(object_list) == 3
     copied_file_content = [
         s3_service.client.get_object(Bucket=S3Service.bucket, Key=copied_obj["Key"])[
             "Body"
@@ -28,7 +30,7 @@ def test_copy(mock_aws):
         .decode("utf-8")
         for copied_obj in object_list
     ]
-    assert copied_file_content == [file_content_1, file_content_2]
+    assert copied_file_content == [file_content_1, file_content_2, file_content_3]
 
 
 def test_copy_raises_incomplete_transaction(mock_aws, mocker):


### PR DESCRIPTION
Preserve S3 "directories" when writing from one prefix to another in the S3 writer. The previous behavior was to flatten the file tree.

Old behavior (bad):

```
intermediate         processed
├── foo.txt     =>   ├── foo.txt
└── subdir           └── bar.txt
    └── bar.txt
```

New behavior (good):

```
intermediate         processed
├── foo.txt     =>   ├── foo.txt
└── subdir           └── subdir
    └── bar.txt          └── bar.txt
```