### PR TITLE
Fix Lambda docker image build for non-x86 architectures

### DIFF
--- a/serverless.yaml
+++ b/serverless.yaml
@@ -8,6 +8,7 @@ provider:
     images:
       okdata-pipeline:
         path: ./
+        platform: linux/amd64
   region: ${opt:region, 'eu-west-1'}
   stage: ${opt:stage, 'dev'}
   timeout: 60


### PR DESCRIPTION
See serverless/pull/10237