### PR TITLE
Beef up the Excel->CSV Lambda

### DIFF
--- a/serverless.yaml
+++ b/serverless.yaml
@@ -82,7 +82,8 @@ functions:
       name: okdata-pipeline
       command:
         - okdata.pipeline.converters.xls.main.xls_to_csv
-    timeout: 120
+    memorySize: 2048
+    timeout: 240
 
 plugins:
   - serverless-better-credentials # must be first


### PR DESCRIPTION
Grant the Excel->CSV Lambda the resources necessary to handle typical Bydelsfakta data loads.

It seems that the new Docker-based runtimes require both more time and memory compared to the previous native Lambda ones.