### PR TITLE
Upgrade okdata-aws to lose vulnerable dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,8 +37,6 @@ deltalake==0.15.3
     # via awswrangler
 deprecation==2.1.0
     # via python-keycloak
-ecdsa==0.18.0
-    # via python-jose
 et-xmlfile==1.1.0
     # via openpyxl
 idna==3.7
@@ -62,9 +60,9 @@ numpy==1.26.4
     #   awswrangler
     #   pandas
     #   pyarrow
-okdata-aws==4.0.0
+okdata-aws==4.1.0
     # via okdata-pipeline (setup.py)
-okdata-sdk==3.1.0
+okdata-sdk==3.1.1
     # via
     #   okdata-aws
     #   okdata-pipeline (setup.py)
@@ -84,21 +82,13 @@ pyarrow==15.0.1
     #   deltalake
 pyarrow-hotfix==0.6
     # via deltalake
-pyasn1==0.5.1
-    # via
-    #   python-jose
-    #   rsa
 pycparser==2.21
     # via cffi
-pyjwt==2.8.0
-    # via okdata-sdk
 python-dateutil==2.9.0.post0
     # via
     #   botocore
     #   okdata-pipeline (setup.py)
     #   pandas
-python-jose==3.3.0
-    # via okdata-sdk
 python-keycloak==3.9.1
     # via okdata-sdk
 pytz==2024.1
@@ -120,14 +110,10 @@ rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
-rsa==4.9
-    # via python-jose
 s3transfer==0.10.0
     # via boto3
 six==1.16.0
-    # via
-    #   ecdsa
-    #   python-dateutil
+    # via python-dateutil
 sniffio==1.3.1
     # via anyio
 starlette==0.37.2

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
         "aws-xray-sdk",
         "boto3",
         "jsonschema",
-        "okdata-aws>=4,<5",
+        "okdata-aws>=4.1",
         "okdata-sdk>=2.1.0",
         "openpyxl",
         "pandas>2,<3",


### PR DESCRIPTION
Remove dependency on the vulnerable ecdsa library by upgrading okdata-aws.