### PR TITLE
Make CSV header parsing more robust

### DIFF
--- a/test/validators/csv/conftest.py
+++ b/test/validators/csv/conftest.py
@@ -25,6 +25,11 @@ def boligpriser_header():
 
 
 @fixture
+def boligpriser_header_with_trailing_whitespace():
+    return ["delbydel_id", "navn ", " pris", " til_salg "]
+
+
+@fixture
 def s3_object(s3_client, s3_bucket):
     def _s3_object(data):
         key = "intermediate/green/foo/bar/test.csv"


### PR DESCRIPTION
Make CSV header parsing more robust by:

1. Ignoring whitespace at the beginning and end of header titles.

2. Detecting unknown headers and giving a proper error message, instead of crashing.